### PR TITLE
Add validation utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./src');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha -R spec 'tests/**/*.test.js'",
-    "lint": "eslint './*.js' 'tests/**/*.js'",
+    "lint": "eslint './*.js' './src/**/*.js' 'tests/**/*.js'",
     "ci": "npm run lint && npm test"
   },
   "keywords": [
@@ -30,5 +30,10 @@
     "eslint-plugin-jsx-a11y": "^1.0.4",
     "eslint-plugin-react": "^5.0.1",
     "mocha": "^2.4.5"
+  },
+  "dependencies": {
+    "ajv": "^4.0.6",
+    "json-schema-defaults": "^0.1.1",
+    "snake-case": "^1.1.2"
   }
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,11 @@
+class ValidationError extends Error {
+  constructor(errors) {
+    super();
+    this.errors = errors;
+  }
+}
+
+
+module.exports = {
+  ValidationError
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+const { defaults, omitReadOnly, validate } = require('./utils');
+const { ValidationError } = require('./errors');
+
+
+module.exports = {
+  defaults,
+  omitReadOnly,
+  validate,
+  ValidationError
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,87 @@
+const schemaDefaults = require('json-schema-defaults');
+const keys = require('lodash/keys');
+const filter = require('lodash/filter');
+const omitBy = require('lodash/omitBy');
+const merge = require('lodash/merge');
+const mapKeys = require('lodash/mapKeys');
+const Validator = require('ajv');
+const snakeCase = require('snake-case');
+const { ValidationError } = require('./errors');
+
+
+function defaults(schema, d) {
+  return merge({}, schemaDefaults(schema), d);
+}
+
+
+function omitReadOnly(schema, d) {
+  // TODO support for values other than single-level object properties
+  return omitBy(d, (v, k) => propertyIsReadOnly(schema, k));
+}
+
+
+function validate(schema, d) {
+  const errors = []
+    .concat(validationErrors(schema, d))
+    .concat(readOnlyErrors(schema, d));
+
+  if (errors.length) throw new ValidationError(errors);
+}
+
+
+function validationErrors(schema, d) {
+  const validator = new Validator({
+    allErrors: true,
+    jsonPointers: true
+  });
+
+  validator.validate(schema, d);
+  return (validator.errors || []).map(parseValidationError);
+}
+
+
+function readOnlyErrors(schema, d) {
+  // TODO support for values other than single-level object properties
+  return filter(keys(d), k => propertyIsReadOnly(schema, k))
+  .map(k => parseReadOnlyError({
+    name: k,
+    path: `/${k}`,
+    schemaPath: `#/${k}/readOnly`
+  }));
+}
+
+
+function parseReadOnlyError({name, path, schemaPath}) {
+  return {
+    type: 'read_only',
+    path,
+    message: `read only property '${name}' given`,
+    details: {},
+    schema_path: schemaPath
+  };
+}
+
+
+function parseValidationError(e) {
+  return {
+    type: snakeCase(e.keyword),
+    path: e.dataPath,
+    message: e.message,
+    details: mapKeys(e.params, (v, k) => snakeCase(k)),
+    schema_path: e.schemaPath
+  };
+}
+
+
+function propertyIsReadOnly(schema, k) {
+  if (!schema.properties) return false;
+  const prop = schema.properties[k];
+  return prop && prop.readOnly;
+}
+
+
+module.exports = {
+  defaults,
+  omitReadOnly,
+  validate
+};

--- a/tests/json-schema-utils.test.js
+++ b/tests/json-schema-utils.test.js
@@ -1,0 +1,138 @@
+const { expect } = require('chai');
+const { captureError } = require('./utils');
+
+const {
+  defaults,
+  omitReadOnly,
+  validate,
+  ValidationError
+} = require('..');
+
+
+describe('json-schema-utils', () => {
+  describe('defaults', () => {
+    it('should return defaults', () => {
+      expect(defaults({
+        type: 'object',
+        properties: {
+          foo: {default: 23},
+          bar: {default: 21},
+          quux: {
+            type: 'object',
+            properties: {
+              corge: {default: 2},
+              grault: {default: 3}
+            }
+          }
+        }
+      }, {
+        foo: 'rar',
+        baz: 1,
+        quux: {
+          corge: 4,
+          garply: 5
+        }
+      }))
+      .to.deep.equal({
+        foo: 'rar',
+        bar: 21,
+        baz: 1,
+        quux: {
+          corge: 4,
+          grault: 3,
+          garply: 5
+        }
+      });
+    });
+  });
+
+  describe('omitReadOnly', () => {
+    it('should omit read only properties', () => {
+      expect(omitReadOnly({
+        type: 'object',
+        properties: {
+          foo: {readOnly: true},
+          bar: {}
+        }
+      }, {
+        foo: 21,
+        bar: 23
+      }))
+      .to.deep.equal({bar: 23});
+    });
+
+    it('should pass through objects for schema without properties', () => {
+      expect(omitReadOnly({}, {
+        foo: 21,
+        bar: 23
+      }))
+      .to.deep.equal({
+        foo: 21,
+        bar: 23
+      });
+    });
+  });
+
+  describe('validate', () => {
+    it('should validate against the schema', () => {
+      expect(validate({type: 'number'}, 23))
+        .to.not.throw;
+
+      const e = captureError(() => validate({
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'object',
+            properties: {
+              bar: {
+                type: 'number'
+              }
+            }
+          }
+        },
+        required: ['foo', 'bar']
+      }, {
+        foo: {bar: 'rar'}
+      }));
+
+      expect(e).to.be.instanceof(ValidationError);
+
+      expect(e.errors).to.deep.equal([{
+        type: 'required',
+        path: '',
+        schema_path: '#/required',
+        details: {missing_property: 'bar'},
+        message: "should have required property 'bar'"
+      }, {
+        type: 'type',
+        path: '/foo/bar',
+        schema_path: '#/properties/foo/properties/bar/type',
+        details: {type: 'number'},
+        message: "should be number"
+      }]);
+    });
+
+    it('should validate read only properties', () => {
+      const e = captureError(() => validate({
+        type: 'object',
+        properties: {
+          foo: {readOnly: true},
+          bar: {}
+        }
+      }, {
+        foo: 21,
+        bar: 23
+      }));
+
+      expect(e).to.be.instanceof(ValidationError);
+
+      expect(e.errors).to.deep.equal([{
+        type: 'read_only',
+        path: '/foo',
+        details: {},
+        schema_path: '#/foo/readOnly',
+        message: "read only property 'foo' given"
+      }]);
+    });
+  });
+});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,15 @@
+function captureError(fn) {
+  try {
+    fn();
+  }
+  catch (e) {
+    return e;
+  }
+
+  return null;
+}
+
+
+module.exports = {
+  captureError
+};


### PR DESCRIPTION
The plan is to bring [these utils](https://github.com/praekelt/numi-api/blob/develop/src/schema-utils.js) here.
